### PR TITLE
Feature player sliding fix

### DIFF
--- a/Confus/Confus/Player.cpp
+++ b/Confus/Confus/Player.cpp
@@ -110,7 +110,7 @@ namespace Confus
     void Player::setLevelCollider(irr::scene::ISceneManager* a_SceneManager,
         irr::scene::ITriangleSelector* a_Level)
     {
-        CameraNode->addAnimator(a_SceneManager->createCollisionResponseAnimator(a_Level, PlayerNode, {0.1f, 0.2f, 0.1f}, { 0, -1, 0 }, {0, 1.5f, 0}));
+        CameraNode->addAnimator(a_SceneManager->createCollisionResponseAnimator(a_Level, PlayerNode, {0.1f, 0.2f, 0.1f}, { 0, -1, 0 }, {0, 1.5f, 0}, 1));
         
         irr::scene::ITriangleSelector* selector = nullptr;
         selector = a_SceneManager->createTriangleSelector(PlayerNode);


### PR DESCRIPTION
Setting the slidingvalue to 1 stops the player from sliding on ramps.
